### PR TITLE
Pharo 9 compatibility

### DIFF
--- a/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testAuthors.st
+++ b/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testAuthors.st
@@ -1,0 +1,6 @@
+tests-accessing
+testAuthors
+	
+	self assert: self project authors isEmpty.
+	self project authors: nil.
+	self assert: self project authors isEmpty.

--- a/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testDefaultSaveDirectory.st
+++ b/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testDefaultSaveDirectory.st
@@ -1,0 +1,4 @@
+tests-accessing
+testDefaultSaveDirectory
+
+	self assert: (self project defaultSaveDirectory isKindOf: AbstractFileReference).

--- a/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testDefaultSaveDirectoryName.st
+++ b/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testDefaultSaveDirectoryName.st
@@ -1,0 +1,4 @@
+tests-accessing
+testDefaultSaveDirectoryName
+
+	self assert: (self project defaultSaveDirectoryName isKindOf: String).

--- a/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testDemo.st
+++ b/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testDemo.st
@@ -1,0 +1,6 @@
+tests-testing
+testDemo
+
+	self deny: self project demo.
+	project demo: true.
+	self assert: self project demo.

--- a/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testIsModified.st
+++ b/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testIsModified.st
@@ -1,0 +1,6 @@
+tests
+testIsModified
+
+	self deny: self project isModified.	
+	self project info modified: true.
+	self assert: self project isModified.

--- a/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testOsVersion.st
+++ b/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testOsVersion.st
@@ -1,0 +1,6 @@
+tests
+testOsVersion
+
+	self assert: self project osVersion isEmpty.	
+	self project osVersion: 'Unix'.
+	self assert: self project osVersion equals: 'Unix'.

--- a/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testProjectExists.st
+++ b/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testProjectExists.st
@@ -1,0 +1,7 @@
+tests-testing
+testProjectExists
+
+	self deny: self project projectExists.
+	self project save.
+	self assert: self project projectExists.
+	

--- a/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testProjectManager.st
+++ b/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testProjectManager.st
@@ -1,0 +1,4 @@
+tests
+testProjectManager
+
+	self should: [ self project projectManager ] raise: SubclassResponsibility.	

--- a/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testRelatedProjects.st
+++ b/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testRelatedProjects.st
@@ -1,0 +1,6 @@
+tests-accessing
+testRelatedProjects
+	
+	self assert: self project relatedProjects isEmpty.
+	self project relatedProjects: nil.
+	self assert: self project relatedProjects isEmpty.

--- a/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testRequiresSaving.st
+++ b/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testRequiresSaving.st
@@ -1,0 +1,6 @@
+tests
+testRequiresSaving
+
+	self deny: self project requiresSaving.	
+	self project info beModified.
+	self assert: self project requiresSaving.

--- a/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testTranslator.st
+++ b/repository/ProjectFramework-Tests.package/PFProjectBaseTest.class/instance/testTranslator.st
@@ -1,0 +1,6 @@
+tests-testing
+testTranslator
+
+	self assert: (self project translator isKindOf: PFTranslator).
+
+	

--- a/repository/ProjectFramework-Tests.package/PFProjectHistoryTest.class/instance/testAddAuthor.st
+++ b/repository/ProjectFramework-Tests.package/PFProjectHistoryTest.class/instance/testAddAuthor.st
@@ -1,0 +1,7 @@
+test
+testAddAuthor
+	
+	user := self newTestUser.
+	self assert: self projectHistory authors isEmpty.
+	self projectHistory addAuthor: user.
+	self assert: (self projectHistory authors includes: user).

--- a/repository/ProjectFramework-Tests.package/PFProjectHistoryTest.class/instance/testAuthors.st
+++ b/repository/ProjectFramework-Tests.package/PFProjectHistoryTest.class/instance/testAuthors.st
@@ -1,0 +1,7 @@
+test
+testAuthors
+	
+	user := self newTestUser.
+	self assert: self projectHistory authors isEmpty.
+	self projectHistory authors: nil.
+	self assert: self projectHistory authors isEmpty.

--- a/repository/ProjectFramework-Tests.package/PFProjectInformationTest.class/instance/testDemo.st
+++ b/repository/ProjectFramework-Tests.package/PFProjectInformationTest.class/instance/testDemo.st
@@ -4,6 +4,6 @@ testDemo
 	| prInf |
 	
 	prInf := self newTestPrjInformation.
-	self assert: prInf demo isNil.	
+	self deny: prInf demo.	
 	prInf demo: true.
 	self assert: prInf demo.

--- a/repository/ProjectFramework-Tests.package/PFProjectInformationTest.class/instance/testRemoveOwner.st
+++ b/repository/ProjectFramework-Tests.package/PFProjectInformationTest.class/instance/testRemoveOwner.st
@@ -1,0 +1,15 @@
+testing
+testRemoveOwner
+
+	| user1 user2 |
+	
+	user1 := PFProjectUser named: 'owner1'.
+	user2 := PFProjectUser named: 'owner2'.
+	project := user addProject: self samplePrjName.
+	
+	project addOwner: user1.
+	project addOwner: user2.
+
+	self assert: ((project removeOwner: user2) isKindOf: PFProjectInformation).
+
+	self should: [ project removeOwner: user2 ] raise: Error.

--- a/repository/ProjectFramework-Tests.package/PFProjectInformationTest.class/instance/testRemoveOwner.st
+++ b/repository/ProjectFramework-Tests.package/PFProjectInformationTest.class/instance/testRemoveOwner.st
@@ -10,6 +10,6 @@ testRemoveOwner
 	project addOwner: user1.
 	project addOwner: user2.
 
-	self assert: ((project removeOwner: user2) isKindOf: PFProjectInformation).
+	self assert: ((project info removeOwner: user2) isKindOf: PFProjectInformation).
 
-	self should: [ project removeOwner: user2 ] raise: Error.
+	self should: [ project info removeOwner: user2 ] raise: Error.

--- a/repository/ProjectFramework.package/PFProjectBase.class/instance/defaultSaveDirectory.st
+++ b/repository/ProjectFramework.package/PFProjectBase.class/instance/defaultSaveDirectory.st
@@ -1,0 +1,5 @@
+defaults
+defaultSaveDirectory
+	" Answer a <AbstractFileReference> with the receiver's serialization directory "
+	
+	^ FileLocator imageDirectory

--- a/repository/ProjectFramework.package/PFProjectBase.class/instance/defaultSaveDirectoryName.st
+++ b/repository/ProjectFramework.package/PFProjectBase.class/instance/defaultSaveDirectoryName.st
@@ -1,0 +1,5 @@
+defaults
+defaultSaveDirectoryName
+	" Answer a <String> with the location where the receiver is serialized "
+	
+	^ self defaultSaveDirectory fullName

--- a/repository/ProjectFramework.package/PFProjectBase.class/instance/projectExists.st
+++ b/repository/ProjectFramework.package/PFProjectBase.class/instance/projectExists.st
@@ -1,0 +1,5 @@
+testing
+projectExists
+	" Answer <true> if the project exists on disk "
+	
+	^ self projectFileReference exists

--- a/repository/ProjectFramework.package/PFProjectBase.class/instance/projectFileReference.st
+++ b/repository/ProjectFramework.package/PFProjectBase.class/instance/projectFileReference.st
@@ -1,0 +1,5 @@
+accessing - serialization
+projectFileReference
+	" Answer a <String> with the receiver's serialization full path "
+	
+	^ self projectFilename asFileReference 

--- a/repository/ProjectFramework.package/PFProjectBase.class/instance/projectFilename.st
+++ b/repository/ProjectFramework.package/PFProjectBase.class/instance/projectFilename.st
@@ -1,0 +1,10 @@
+accessing - serialization
+projectFilename
+	" Answer a <String> with the receiver's serialization full path "
+	
+	^ String streamContents: [ : stream |
+		stream 	
+			nextPutAll: self defaultSaveDirectoryName;
+			nextPutAll: self platformSeparator;
+			nextPutAll: info infoName;
+			nextPutAll: self projectFileExtension ]

--- a/repository/ProjectFramework.package/PFProjectBase.class/instance/remove.st
+++ b/repository/ProjectFramework.package/PFProjectBase.class/instance/remove.st
@@ -2,9 +2,9 @@ accessing - serialization
 remove
 	" Remove the receiver from disk if the receiver was persisted and raise a Remove notification. If project does not exists as a file, just raise a Close notification. "
 	
-	self fileName asFileReference exists
+	self projectExists
 		ifTrue: [ 
-			self fileName asFileReference delete.
+			self projectFileReference delete.
 			self release.
 			PFSuccessRemove signal: 'Successfully removed' ]
 		ifFalse: [ 

--- a/repository/ProjectFramework.package/PFProjectBase.class/instance/saveProjectFile.st
+++ b/repository/ProjectFramework.package/PFProjectBase.class/instance/saveProjectFile.st
@@ -2,6 +2,8 @@ private
 saveProjectFile
 	" Private - Save the receiver's information into the project file "
 
+	self projectExists
+		ifFalse: [ self projectFileReference ensureCreateFile ].
 	self serializerClass 
 		serialize: self 
-		toFileNamed: self info infoName , self projectFileExtension
+		toFileNamed: self projectFilename

--- a/repository/ProjectFramework.package/PFProjectHistory.class/instance/addAuthor..st
+++ b/repository/ProjectFramework.package/PFProjectHistory.class/instance/addAuthor..st
@@ -1,0 +1,5 @@
+accessing
+addAuthor: aPFProjectUser
+	" Add aPFProjectUser to the receiver's collection of authors "
+	
+	self authors add: aPFProjectUser

--- a/repository/ProjectFramework.package/PFProjectInformation.class/instance/addOwner..st
+++ b/repository/ProjectFramework.package/PFProjectInformation.class/instance/addOwner..st
@@ -7,4 +7,4 @@ addOwner: aPFProjectUser
 		ifFalse: [ 
 			self usage addOwner: aPFProjectUser.
 			aPFProjectUser addUserProject: self project ]
-		ifTrue: [ Exception signal: aPFProjectUser 	userName , ' is already an owner of project: ' , self project projectName ]
+		ifTrue: [ Error signal: aPFProjectUser 	userName , ' is already an owner of project: ' , self project projectName ]

--- a/repository/ProjectFramework.package/PFProjectInformation.class/instance/demo.st
+++ b/repository/ProjectFramework.package/PFProjectInformation.class/instance/demo.st
@@ -3,3 +3,4 @@ demo
 	" Answer <true> if the receiver represents a demo project "
 
 	^ demo
+		ifNil: [ demo := false ]


### PR DESCRIPTION
Enforce location of serialized projects to be a writable FileReference
Add tests
By default a new project is not a demo project